### PR TITLE
feat: add clamd IDSESSION support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ homepage = "https://github.com/LevitatingOrange/clamd-client"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["net", "io-util", "fs"]}
-futures = { version = "0.3" }
-tracing = { version = "0.1" }
-thiserror = { version = "1.0" }
 bytes = { version = "1" }
+futures = { version = "0.3" }
+socket2 = { version = "0.4" }
+thiserror = { version = "1.0" }
+tokio = { version = "1", features = ["net", "io-util", "fs"]}
 tokio-util = { version = "0.7", features = ["codec"]}
+tracing = { version = "0.1" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let address = "127.0.0.1:3310";
-    let mut clamd_client = ClamdClientBuilder::tcp_socket(address).build();
+    let mut clamd_client = ClamdClientBuilder::tcp_socket(&address.parse()?).build();
     clamd_client.ping().await?;
     info!("Ping worked!");
     clamd_client.reload().await?;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let address = "127.0.0.1:3310";
-    let mut clamd_client = ClamdClientBuilder::tcp_socket(&address.parse()?).build();
+    let mut clamd_client = ClamdClientBuilder::tcp_socket(address)?.build();
     clamd_client.ping().await?;
     info!("Ping worked!");
     clamd_client.reload().await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,6 @@ pub enum ClamdError {
         #[source]
         std::io::Error,
     ),
-
     /// Occurs when the response from clamd is not what the library
     /// expects. Contains the invalid response.
     #[error("invalid response from clamd: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,9 @@ pub type Result<T> = std::result::Result<T, ClamdError>;
 /// Errors that can occur when using [`ClamdClient`].
 #[derive(Debug, thiserror::Error)]
 pub enum ClamdError {
+    /// Occurs when the socket address input could not be parsed.
+    #[error("error parsing socket address: {0}")]
+    AddrParsingError(#[source] std::io::Error),
     /// Occurs when the custom set chunk size is larger than
     /// [`std::u32::MAX`].
     #[error("could not send chunk: too large: {0}")]
@@ -59,7 +62,7 @@ impl ClamdError {
     /// # use eyre::Result;
     /// # async fn doc() -> eyre::Result<()> {
     /// let address = "127.0.0.1:3310".parse::<SocketAddr>()?;
-    /// let mut clamd_client = ClamdClientBuilder::tcp_socket(&address).build();
+    /// let mut clamd_client = ClamdClientBuilder::tcp_socket(address)?.build();
     ///
     /// // This downloads a virus signature that is benign but trips clamd.
     /// let eicar_bytes = reqwest::get("https://secure.eicar.org/eicarcom2.zip")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,9 +348,9 @@ struct ConnectedSocket {
 impl ClamdClient {
     async fn connect(&mut self) -> Result<MutexGuard<'_, ConnectedSocket>> {
         let codec = ClamdZeroDelimitedCodec::new();
+        let mut guard = self.shared.state.lock().await;
         match &self.shared.connection_type {
             ConnectionType::Oneshot => {
-                let mut guard = self.shared.state.lock().await;
                 guard.socket = match &self.shared.socket_type {
                     SocketType::Tcp(address) => Some(Framed::new(
                         SocketWrapper::Tcp(
@@ -371,7 +371,6 @@ impl ClamdClient {
                 }
             }
             ConnectionType::KeepAlive => {
-                let mut guard = self.shared.state.lock().await;
                 if guard.socket.is_none() {
                     guard.socket = match &self.shared.socket_type {
                         SocketType::Tcp(address) => {
@@ -394,7 +393,7 @@ impl ClamdClient {
                 }
             }
         };
-        Ok(self.shared.state.lock().await)
+        Ok(guard)
     }
 
     /// Ping clamd. If it responds normally (with `PONG`) this function returns `Ok(())`, otherwise

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,22 +114,23 @@ impl Encoder<ClamdRequestMessage> for ClamdZeroDelimitedCodec {
                 Ok(())
             }
             ClamdRequestMessage::StartSession => {
-                dst.reserve(10);
+                dst.reserve(11);
                 dst.put(&b"zIDSESSION"[..]);
                 dst.put_u8(0);
                 Ok(())
             }
             ClamdRequestMessage::EndSession => {
-                dst.reserve(10);
+                dst.reserve(5);
                 dst.put(&b"zEND"[..]);
                 dst.put_u8(0);
                 Ok(())
             }
             ClamdRequestMessage::ContScan(path) => {
-                dst.reserve(10);
-                dst.put(&b"zCONTSCAN "[..]);
                 // TODO: safety
-                dst.put(path.to_str().unwrap().as_bytes());
+                let path = path.to_str().unwrap();
+                dst.reserve(10 + path.len());
+                dst.put(&b"zCONTSCAN "[..]);
+                dst.put(path.as_bytes());
                 dst.put_u8(0);
                 Ok(())
             }


### PR DESCRIPTION
Hello !

Thanks for the great library. I've taken the liberty to add `ConnectionType::KeepAlive` support by using clamd's `IDSESSION` command.
I haven't tested every command in the keep alive mode yet, there may be some issues on parsing. Also, it may be needed to send an error when a command is used and not supported by `IDSESSION`. From the man page, I see that the following are supported but it's unclear if that's the case:
```
SCAN, INSTREAM,  FILDES, VERSION,  STATS
```

Other things:
- It felt reasonable to change the `SocketType::Tcp(T: ToSocketAddrs)` to `SocketType::Tcp(SocketAddr)`, not adding much burden on the user and at the same time removing the need for generics.
- I'd like to add the setup & run of the clamd daemon in the test suite in this PR, but I could also do it in subsequent PRs if you wish :)
- Also planning to add the `CONTSCAN` command as you can probably see, I can do that in another PR too if you prefer.
- I'm personally not fond of qualifying a virus detection as an Error, I think the approach of having a `ScanResult` enum or something of the like suits the problem better, wdyt?