### PR TITLE
feat: add multiscan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clamd-client"
 description = "Rust async tokio client for clamd. Works with a tcp socket or with the unix socket. At the moment it will open a new socket for each command. Work in progress."
-keywords = ["clamd", "clamav", "virus-scanning", ]
+keywords = ["clamd", "clamav", "virus-scanning"]
 version = "0.1.2"
 edition = "2021"
 authors = ["Lennart Vogelsang <lennart@vogelsang.berlin>"]
@@ -13,18 +13,18 @@ homepage = "https://github.com/LevitatingOrange/clamd-client"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = { version = "1" }
-futures = { version = "0.3" }
-socket2 = { version = "0.4" }
-thiserror = { version = "1.0" }
-tokio = { version = "1", features = ["net", "io-util", "fs"]}
-tokio-util = { version = "0.7", features = ["codec"]}
-tracing = { version = "0.1" }
+bytes = "1"
+futures = "0.3"
+socket2 = "0.5"
+thiserror = "2.0"
+tokio = { version = "1", features = ["net", "io-util", "fs"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+tracing = "0.1"
 
 [dev-dependencies]
+eyre = "0.6"
+rand = "0.9"
+reqwest = "0.12"
 tokio = { version = "1", features = ["full"] }
-eyre = { version = "0.6" }
 tracing-subscriber = "0.3"
-rand = { version = "0.8"}
 tracing-test = "0.2"
-reqwest = "0.11"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,6 @@
 use crate::ClamdClient;
 use std::num::TryFromIntError;
 
-use tracing::trace;
-
 pub type Result<T> = std::result::Result<T, ClamdError>;
 
 /// Errors that can occur when using [`ClamdClient`].
@@ -32,6 +30,9 @@ pub enum ClamdError {
         #[source]
         std::io::Error,
     ),
+    /// Occurs when the file path is not utf8.
+    #[error("invalid path")]
+    InvalidPath,
     /// Occurs when the response from clamd is not what the library
     /// expects. Contains the invalid response.
     #[error("invalid response from clamd: {0}")]
@@ -44,49 +45,6 @@ pub enum ClamdError {
     /// is somehow malformed. Contains the invalid response.
     #[error("incomplete response from clamd: {0}")]
     IncompleteResponse(String),
-    /// Occurs when everything between this library and clamd went
-    /// well but clamd seems to have found a virus signature. See also
-    /// [`ClamdError::scan_error`].
-    #[error("clamd returned error on scan, possible virus: {0}")]
-    ScanError(String),
-}
-
-impl ClamdError {
-    /// If you want to ignore any error but an actual malignent scan
-    /// result from clamd. I do not recommend using this without careful thought, as any other error
-    /// could hide that uploaded bytes are actually a virus.
-    /// # Example
-    /// ```rust
-    /// # use std::net::SocketAddr;
-    /// # use clamd_client::{ClamdClientBuilder, ScanResult};
-    /// # use eyre::Result;
-    /// # async fn doc() -> eyre::Result<()> {
-    /// let address = "127.0.0.1:3310".parse::<SocketAddr>()?;
-    /// let mut clamd_client = ClamdClientBuilder::tcp_socket(address)?.build();
-    ///
-    /// // This downloads a virus signature that is benign but trips clamd.
-    /// let eicar_bytes = reqwest::get("https://secure.eicar.org/eicarcom2.zip")
-    ///   .await?
-    ///   .bytes()
-    ///   .await?;
-    ///
-    /// let result = clamd_client.scan_bytes(&eicar_bytes).await?;
-    /// match result {
-    ///     ScanResult::Malignent { infection_types } => {
-    ///         tracing::info!("clamd found a virus(es):\n{}", infection_types.join("\n"))
-    ///     }
-    ///     _ => (),
-    /// };
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn scan_error(self) -> Option<String> {
-        match self {
-            Self::ScanError(s) => Some(s),
-            _ => {
-                trace!("ignoring non-scan error {:?}", self);
-                None
-            }
-        }
-    }
+    #[error("unsupported feature: path must point to file")]
+    UnsupportedFeature,
 }


### PR DESCRIPTION
* fix: concurrency issues

I was having an issue in production where in a multithreaded context when using ClamdClient with `ConnectionType::Oneshot` the connections were dropped at every `connect` call (only the last one calling connect "won").

That was due to a poor quality of coding on my behalf, sorry about that!